### PR TITLE
Support SSL on CF

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The application can be configured via the following environment variables:
 | ---------------------------------|-------------------------------------------------------------|
 | AUTH_USERNAME                    | Basic authentication username                               |
 | AUTH_PASSWORD                    | Basic authentication password                               |
+| CF_INSTANCE_CERT                 | SSL Certificate (optional to support ssl)                   |
+| CF_INSTANCE_KEY                  | SSL Certificate Key (optional to support ssl)               |
 | FROM                             | Email address to send emails from                           |
 | HOST                             | Host for the http server                                    |
 | PORT                             | Port for the http server                                    |

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,8 +9,7 @@ applications:
   - nodejs_buildpack
   instances: 2
   memory: 256MB
-  health-check-type: http
-  health-check-http-endpoint: /health
+  health-check-type: port
   env:
     FROM: no-reply@gsa.gov
     HOST: "0.0.0.0"

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,10 @@
+import fs from 'fs';
+
 const {
   AUTH_USERNAME,
   AUTH_PASSWORD,
+  CF_INSTANCE_CERT,
+  CF_INSTANCE_KEY,
   FROM,
   HOST,
   PORT,
@@ -18,6 +22,13 @@ export const auth = {
 };
 
 export const host = HOST;
+
+export const https = CF_INSTANCE_CERT
+  ? {
+    cert: fs.readFileSync(CF_INSTANCE_CERT),
+    key: fs.readFileSync(CF_INSTANCE_KEY),
+  }
+  : null;
 
 export const port = PORT;
 
@@ -43,5 +54,5 @@ export const mailer = TRANSPORT === 'smtp'
   };
 
 export default {
-  auth, host, mailer, port,
+  auth, host, https, mailer, port,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import app from './app.js';
-import config, { host, port } from './config.js';
+import config, { host, https, port } from './config.js';
 
 const start = async () => {
   const server = await app({
     config,
+    https,
     logger: true,
   });
 


### PR DESCRIPTION
Resolves 18F/federalist#3653

## Changes proposed in this pull request:
- Implements TLS for http connections using the CF provided cert

## Security considerations
The CF provided certificate does not include a SAN for the actual domain of this application so http clients must be lax in enforcing in certain validations of the certificate. In `node` this can be accomplished by provided `rejectUnauthorized: false` to the underlying `TLSSocket`. Connections will still be encrypted and access to this service is restricted to containers on the internal network for which a container-to-container policy has been created.

