### PR TITLE
Remove inclusion of slack-users variable in Concourse Slack job status messages

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -138,7 +138,6 @@ jobs:
       text: |
         :x: FAILED: pages mailer deployment
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        ((slack-users))
       channel: ((slack-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
@@ -149,7 +148,6 @@ jobs:
       text: |
         :white_check_mark: SUCCESS: Successfully deployed pages mailer
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        ((slack-users))
       channel: ((slack-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove inclusion of slack-users variable in Concourse Slack job status messages

## security considerations
None
