### PR TITLE
Remove tls from app and rely on platform C2C encryption

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,6 @@
-import fs from 'fs';
-
 const {
   AUTH_USERNAME,
   AUTH_PASSWORD,
-  CF_INSTANCE_CERT,
-  CF_INSTANCE_KEY,
   FROM,
   HOST,
   PORT,
@@ -22,13 +18,6 @@ export const auth = {
 };
 
 export const host = HOST;
-
-export const https = CF_INSTANCE_CERT
-  ? {
-    cert: fs.readFileSync(CF_INSTANCE_CERT),
-    key: fs.readFileSync(CF_INSTANCE_KEY),
-  }
-  : null;
 
 export const port = PORT;
 
@@ -54,5 +43,5 @@ export const mailer = TRANSPORT === 'smtp'
   };
 
 export default {
-  auth, host, https, mailer, port,
+  auth, host, mailer, port,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 import app from './app.js';
-import config, { host, https, port } from './config.js';
+import config, { host, port } from './config.js';
 
 const start = async () => {
   const server = await app({
     config,
-    https,
     logger: true,
   });
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addresses #12 
- Removes TLS from and rely on C2C encryption

## Security considerations
Rely on CG proovided container to container encryption
