### PR TITLE
Update node version to pull LTS of Node.js v16

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,7 @@ node-image: &node-image
   type: docker-image
   source:
     repository: node
-    tag: 16.14
+    tag: 16
 
 cf-image: &cf-image
   platform: linux
@@ -119,7 +119,7 @@ jobs:
         path: ci/tasks/deploy.sh
     params:
       <<: *email-cf
-      
+
     on_failure:
       try:
         task: cancel-deployment
@@ -169,7 +169,7 @@ jobs:
     params:
       <<: *email-cf
 
-- name: reconfigure
+- name: set-pipeline
   serial: true
   plan:
     - get: src
@@ -199,7 +199,7 @@ resources:
     type: git
     icon: github
     source:
-      uri: https://github.com/cloud-gov/pages-mailer   
+      uri: https://github.com/cloud-gov/pages-mailer
       branch: main
 
   - name: nightly
@@ -208,7 +208,7 @@ resources:
       start: 12:00 AM
       stop: 1:00 AM
       location: America/New_York
-  
+
   - name: slack
     type: slack-notification
     source:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "tap": "^16.2.0"
       },
       "engines": {
-        "node": "16.14.x",
-        "npm": "8.x.x"
+        "node": "^16.x.x",
+        "npm": "^8.x.x"
       }
     },
     "node_modules/@babel/compat-data": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "git://github.com/cloud-gov/pages-mailer.git"
   },
   "engines": {
-    "node": "16.14.x",
-    "npm": "8.x.x"
+    "node": "^16.x.x",
+    "npm": "^8.x.x"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use node v16 lts
- Fixes nightly redeploy since the previously specified node version is no longer available in cloud.gov's buildpack.

## Security considerations
Pulls LTS version of Node v16
