### PR TITLE
Successfully set pipeline before running deploy and nightly tasks

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -106,6 +106,7 @@ jobs:
   - get: src
     resource: src
     trigger: true
+    passed: [set-pipeline]
     params: {depth: 1}
 
   - do: *test
@@ -156,6 +157,7 @@ jobs:
   plan:
   - get: src
     resource: src
+    passed: [set-pipeline]
     params: {depth: 1}
   - get: nightly
     trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Successfully run and pass `set-pipeline` before deploy/nightly tasks run

## Security considerations
None
