### PR TITLE
ci: Verify git commits with gpg keys

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -203,6 +203,7 @@ resources:
     source:
       uri: https://github.com/cloud-gov/pages-mailer
       branch: main
+      commit_verification_keys: ((cloud-gov-pages-gpg-keys))
 
   - name: nightly
     type: time


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2480

## Changes proposed in this pull request:
- Adds commit verification to Git resources to check team GPG keys

## security considerations
Adds commit verification to Git resources to check team GPG keys