### PR TITLE
Use correct cf-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,9 +28,9 @@ cf-image: &cf-image
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: pages-dind-v25
+      repository: harden-concourse-task
       aws_region: us-gov-west-1
-      tag: latest
+      tag: ((harden-concourse-task-tag))
 
 test: &test
 - task: install-deps


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update pipeline to use the correct image for `cf-image`

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None. This is a correction to the preceding chore PR which switched to hardened images.
