### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/pages-ops


### PR DESCRIPTION
Closes https://github.com/cloud-gov/product/issues/3404

## Changes proposed in this pull request:

- Adds pages ops as code owners

## Security considerations

Owned up
